### PR TITLE
patch/course-permissions-add-course-names

### DIFF
--- a/src/coursePermissions/coursePermissionsModel.js
+++ b/src/coursePermissions/coursePermissionsModel.js
@@ -19,7 +19,6 @@ const getCoursePermissionById = (id) => {
 const getPermissionByCourseId = (id) => {
     return db('course_permissions')
         .where({ course_id: id })
-        .where({ access_granted: true })
         .select('*')
 }
 

--- a/src/coursePermissions/coursePermissionsRouter.js
+++ b/src/coursePermissions/coursePermissionsRouter.js
@@ -1,15 +1,25 @@
 const express = require('express');
 const router = express.Router();
 const CoursePermissions = require('./coursePermissionsModel');
+const Courses = require('../courses/coursesModel');
 
 // Get all course permissions
 router.get('/', function (req, res) {
     CoursePermissions.getAllCoursePermissions()
-        .then((response) => {
-            res.status(200).json(response);
+        .then(async (response) => {
+            let permissions = response.map(async (i) => {
+                await Courses.getCourseById(i.course_id)
+                .then((course) => {
+                    i.course_name = course.name;
+                })
+                return i;
+            })
+            Promise.all(permissions).then((permissions) => {
+                res.status(200).json(permissions);
+            })
         })
         .catch((err) => {
-            res.status(err.status).json({ message: err.message });
+            res.status(500).json(err);
         })
 })
 

--- a/src/data/migrations/20230720165347_course_permissions.js
+++ b/src/data/migrations/20230720165347_course_permissions.js
@@ -20,7 +20,6 @@ exports.up = async (knex) => {
             .inTable('courses')
             .onDelete('CASCADE')
             .onUpdate('CASCADE')
-        table.boolean('access_granted').notNullable()
         table.timestamps(true, true)
       })
   }

--- a/src/data/seeds/07_course_permissions.js
+++ b/src/data/seeds/07_course_permissions.js
@@ -2,52 +2,26 @@ const course_permissions = [
   {
     chapter_id: 1,
     course_id: 1,
-    access_granted: true
   },
   {
     chapter_id: 1,
     course_id: 2,
-    access_granted: true
   },
   {
     chapter_id: 2,
     course_id: 1,
-    access_granted: true
-  },
-  {
-    chapter_id: 2,
-    course_id: 2,
-    access_granted: false
-  },
-  {
-    chapter_id: 3,
-    course_id: 1,
-    access_granted: false
   },
   {
     chapter_id: 3,
     course_id: 2,
-    access_granted: true
-  },
-  {
-    chapter_id: 4,
-    course_id: 1,
-    access_granted: false
-  },
-  {
-    chapter_id: 4,
-    course_id: 2,
-    access_granted: false
   },
   {
     chapter_id: 5,
     course_id: 1,
-    access_granted: true
   },
   {
     chapter_id: 5,
     course_id: 2,
-    access_granted: true
   },
 ];
 


### PR DESCRIPTION
This pull request adds course names to the course permissions objects being returned when the app hits the `/coursePermissions` endpoint in order to then render those course names associated with each chapter in the front end's chapter details pages.

It also removes the `access_granted` flags from `course_permissions` objects, and cleans up our database migrations and seeds to match.